### PR TITLE
Update repository URL after deb-builder → deb-toolkit rename

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Mina Protocol Team"]
 description = "Build, sign, verify, and inspect Debian packages"
 license = "Apache-2.0"
-repository = "https://github.com/MinaProtocol/deb-builder"
+repository = "https://github.com/MinaProtocol/deb-toolkit"
 
 [[bin]]
 name = "deb-toolkit"


### PR DESCRIPTION
One-line fix-up to `Cargo.toml` after the GitHub repo rename. No code changes.